### PR TITLE
Simple change to Row.Iterator and Row.Extractor which should allow for a

### DIFF
--- a/src/main/java/db/postgresql/async/Row.java
+++ b/src/main/java/db/postgresql/async/Row.java
@@ -22,6 +22,9 @@ public interface Row {
     public interface Extractor {
         Object getAt(String field);
         Object getAt(int index);
+
+        String stringAt(String field);
+        String stringAt(int index);
         
         boolean booleanAt(String field);
         boolean booleanAt(int field);


### PR DESCRIPTION
fairly intuitive use of both text and binary formats.

Binary formats utilize the serializer format, except in the case of
nextString() which always returns a string. next() always returns the
typed value. Binary formats are a "programmer centric" view of the
database.

Text formats always used the string format, except in the case of
primitive extractors (nextInt(), nextDouble() etc.). next() always
returns the string value. Text is the "human centric" view of the
database.

Yes, this means that programmers are not humans.
